### PR TITLE
Fix crush when sending more than one parameter with null value

### DIFF
--- a/src/jschannel.js
+++ b/src/jschannel.js
@@ -673,7 +673,9 @@
                         if (seen.indexOf(obj) >= 0) {
                             throw "params cannot be a recursive data structure"
                         }
-                        seen.push(obj);
+                        if(obj) {
+                            seen.push(obj);
+                        }
 
                         if (typeof obj === 'object') {
                             for (var k in obj) {


### PR DESCRIPTION
Hi,
this fix JSChannel error when sending more than one parameter with null values.
## 

Marko
